### PR TITLE
fix(json): expose deserialization error codes & prevent overwriting invalid configs

### DIFF
--- a/scripts/mikk155/meta_api/json.as
+++ b/scripts/mikk155/meta_api/json.as
@@ -14,6 +14,14 @@ namespace meta_api
             V2
         };
 
+        enum Error
+        {
+            OK = 0,
+            FILE_NOT_FOUND,
+            SYNTAX_ERROR,
+            EMPTY_INPUT
+        };
+
         /// Latest available version
         const Version Latest = Version::V2;
 
@@ -550,6 +558,15 @@ namespace meta_api
                 }
 
                 private
+                    meta_api::json::Error m_ErrorCode = meta_api::json::Error::OK;
+
+                const meta_api::json::Error get_ErrorCode() const {
+                    if( this.error > 0 )
+                        return meta_api::json::Error::SYNTAX_ERROR;
+                    return this.m_ErrorCode;
+                }
+
+                private
                     string m_FileName;
 
                 /// The file name
@@ -707,6 +724,7 @@ namespace meta_api
                     this.m_IsFile = false;
                     this.m_totalSize = this.m_CurrentLine = this.m_CurrentLinePosition = this.m_CurrentPosition = 0;
                     this.m_Buffer.Clear();
+                    this.m_ErrorCode = meta_api::json::Error::OK;
                 }
 
                 ~Deserializer()
@@ -733,6 +751,7 @@ namespace meta_api
                     if( !this.IsFile && this.m_Buffer.IsEmpty() )
                     {
                         this.Logger.error( snprintf( cout, "Deserializer::Initialize Empty string provided or Deserializer::SetSerialized was never called!" ) );
+                        this.m_ErrorCode = meta_api::json::Error::EMPTY_INPUT;
                         return meta_api::json::Type::Undefined;
                     }
 
@@ -763,6 +782,7 @@ namespace meta_api
                             if( fstream is null || !fstream.IsOpen() )
                             {
                                 this.Logger.error( snprintf( cout, "could not open file \"%1\"", this.m_FileName ) );
+                                this.m_ErrorCode = meta_api::json::Error::FILE_NOT_FOUND;
                                 return meta_api::json::Type::Undefined;
                             }
 
@@ -790,6 +810,7 @@ namespace meta_api
                     if( this.totalSize <= 1 ) // 2 is the minimun string size to define empty object/array
                     {
                         this.Logger.error( "The provided string is empty!" );
+                        this.m_ErrorCode = meta_api::json::Error::EMPTY_INPUT;
                         return meta_api::json::Type::Undefined;
                     }
 
@@ -798,7 +819,10 @@ namespace meta_api
                     while( this.CurrentPosition < this.totalSize )
                     {
                         if( !SkipComments() )
+                        {
+                            this.m_ErrorCode = meta_api::json::Error::SYNTAX_ERROR;
                             break;
+                        }
 
                         check = buffer[this.CurrentPosition];
                         this.AdvancePosition(1);
@@ -812,6 +836,7 @@ namespace meta_api
                             break;
                     }
                     this.ErrorUnexpected( "{\" or \"[", check );
+                    this.m_ErrorCode = meta_api::json::Error::SYNTAX_ERROR;
                     return meta_api::json::Type::Undefined;
                 }
 

--- a/scripts/mikk155/meta_api/json/v1.as
+++ b/scripts/mikk155/meta_api/json/v1.as
@@ -20,6 +20,11 @@ namespace meta_api
                 {
                     obj.deleteAll();
 
+                    if( objectType != meta_api::json::Type::Object && objectType != meta_api::json::Type::Array )
+                    {
+                        return false;
+                    }
+
                     meta_api::json::parser::KeyValuePair@ pair;
 
                     while( this.Advance( objectType, pair ) )
@@ -169,6 +174,30 @@ namespace meta_api
                 }
 #endif
                 return Deserializer.Parse( obj, Deserializer.Initialize() );
+            }
+
+            bool Deserialize( const string&in str, dictionary&out obj, meta_api::json::Error&out err )
+            {
+                meta_api::json::v1::__Deserializer__ Deserializer();
+                Deserializer.SetSerialized(str);
+#if METAMOD_PLUGIN_ASLP
+                if( __METAMOD__ )
+                {
+                    bool result = false;
+                    if( Deserializer.IsFile )
+                        result = aslp::json::Deserialize( Deserializer.FileName, obj );
+                    else
+                        result = aslp::json::Deserialize( Deserializer.buffer, obj );
+                    if( result )
+                        err = meta_api::json::Error::OK;
+                    else
+                        err = meta_api::json::Error::SYNTAX_ERROR;
+                    return result;
+                }
+#endif
+                bool result = Deserializer.Parse( obj, Deserializer.Initialize() );
+                err = Deserializer.ErrorCode;
+                return result;
             }
         }
     }

--- a/scripts/mikk155/meta_api/json/v2.as
+++ b/scripts/mikk155/meta_api/json/v2.as
@@ -240,6 +240,11 @@ namespace meta_api
                     return Deserialize( str, this );
                 }
 
+                bool Load( const string&in str, meta_api::json::Error&out err )
+                {
+                    return Deserialize( str, this, err );
+                }
+
                 /// ======================================
                 /// Object/Array methods
                 /// ======================================
@@ -706,6 +711,11 @@ namespace meta_api
 
                     obj.SetType( objectType );
 
+                    if( objectType != meta_api::json::Type::Object && objectType != meta_api::json::Type::Array )
+                    {
+                        return false;
+                    }
+
                     meta_api::json::parser::KeyValuePair@ pair;
 
                     while( this.Advance( objectType, pair ) )
@@ -854,6 +864,15 @@ namespace meta_api
                 meta_api::json::v2::__Deserializer__ Deserializer();
                 Deserializer.SetSerialized(str);
                 return Deserializer.Parse( obj, Deserializer.Initialize() );
+            }
+
+            bool Deserialize( const string&in str, meta_api::json::v2::json@&out obj, meta_api::json::Error&out err )
+            {
+                meta_api::json::v2::__Deserializer__ Deserializer();
+                Deserializer.SetSerialized(str);
+                bool result = Deserializer.Parse( obj, Deserializer.Initialize() );
+                err = Deserializer.ErrorCode;
+                return result;
             }
         } // v2
     } // json

--- a/scripts/mikk155/meta_api/json/v2/interface.as
+++ b/scripts/mikk155/meta_api/json/v2/interface.as
@@ -45,6 +45,7 @@ interface JToken
     *   If str is a file and is pointing to store/ and the file couldn't be opened it will be writed and return a valid handle
     **/
     bool Load( const string&in str );
+    bool Load( const string&in str, meta_api::json::Error&out err );
     /// Set key value pair, return the old value if it exists otherwise null
     meta_api::json::v2::json@ Set( const string&in keyName, meta_api::json::v2::json@ value );
     meta_api::json::v2::json@ Set( const string&in keyName, const bool value );

--- a/scripts/mikk155/meta_api/json/v2/tests.as
+++ b/scripts/mikk155/meta_api/json/v2/tests.as
@@ -128,6 +128,35 @@ namespace meta_api
                         && Deserialize( "{\"int\":2}", obj )
                         && schema::Validate( obj, "{\"type\":\"object\",\"properties\":{\"int\":{\"type\":\"integer\",\"maximum\":2}}}" )
                     );
+
+                    // ============================
+                    // ======== error code test ===
+                    // ============================
+                    meta_api::json::Error testErr;
+
+                    // Valid JSON
+                    Expect( "[Error] Valid JSON OK", true,
+                        Deserialize( "{\"key\": 1}", obj, testErr )
+                        && testErr == meta_api::json::Error::OK
+                    );
+
+                    // Empty Input
+                    Expect( "[Error] Empty input", true,
+                        !Deserialize( "", obj, testErr )
+                        && testErr == meta_api::json::Error::EMPTY_INPUT
+                    );
+
+                    // Syntax Error
+                    Expect( "[Error] Syntax error", true,
+                        !Deserialize( "{invalid}", obj, testErr )
+                        && testErr == meta_api::json::Error::SYNTAX_ERROR
+                    );
+
+                    // File Not Found
+                    Expect( "[Error] File not found", true,
+                        !Deserialize( "nonexistent_file_path_test.json", obj, testErr )
+                        && testErr == meta_api::json::Error::FILE_NOT_FOUND
+                    );
                 }
             }
         }

--- a/scripts/plugins/anticlip.as
+++ b/scripts/plugins/anticlip.as
@@ -73,12 +73,20 @@ void MapActivate()
     {
         meta_api::json::v2::json@ data;
 
-        bool failedLoad;
+        bool failedLoad = false;
+        meta_api::json::Error err = meta_api::json::Error::OK;
 
-        if( !meta_api::json::v2::Deserialize( "store/anticlip.json", data ) )
+        if( !meta_api::json::v2::Deserialize( "store/anticlip.json", data, err ) )
         {
             @data = meta_api::json::v2::json();
-            failedLoad = true;
+            if( err == meta_api::json::Error::FILE_NOT_FOUND )
+            {
+                failedLoad = true;
+            }
+            else
+            {
+                g_Game.AlertMessage( at_console, "Anti-Clip JSON parsing failed with error code: %1. Config file preserved.\n", int(err) );
+            }
         }
 
         auto@ Schema = meta_api::json::v2::json();


### PR DESCRIPTION
### Description

This Pull Request resolves a issue where invalid JSON configuration files (e.g., files with syntax errors or typos) were completely wiped and overwritten by default configurations during loading.

### Key Changes
1. **Added `meta_api::json::Error` Enum**: Defines detailed states for deserialization (`OK`, `FILE_NOT_FOUND`, `SYNTAX_ERROR`, `EMPTY_INPUT`).
2. **Detailed Error Reporting in `Deserializer`**: The base `Deserializer` class now tracks the specific error reason in `m_ErrorCode` (accessible via the `ErrorCode` property).
3. **Overloaded `Deserialize` and `Load` Signatures**: Added overloads accepting a `meta_api::json::Error&out err` parameter in both `v1` and `v2` APIs, preserving backwards compatibility for other plugins.
4. **Early Exit for Undefined Root**: Protected `Parse` from calling `Advance` on an undefined root container type, ensuring `this.error` remains accurate.
5. **Robust Configuration Saving in `anticlip.as`**: Updated the plugin's configuration loading so that default configuration templates are only written to disk if the file is completely missing (`FILE_NOT_FOUND`). For syntax errors or empty inputs, it logs a warning to the console, uses fallback defaults in memory, and preserves the user's config file on disk intact.
6. **Tests**: Integrated new test cases covering all error codes in `tests.as`.